### PR TITLE
Fix remaining vcam-bg references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ Python-*/
 squashfs-root/
 
 # Generated files
-vcam-bg
+vidmask
 errors.md
 
 # Cursor rules

--- a/src/config.py
+++ b/src/config.py
@@ -3,7 +3,7 @@ import json
 
 class Config:
     def __init__(self):
-        self.config_file = os.path.expanduser('~/.config/vcam-bg/config.json')
+        self.config_file = os.path.expanduser('~/.config/vidmask/config.json')
         self.config = self.load()
 
     def load(self):


### PR DESCRIPTION
# Fix remaining vcam-bg references

This PR fixes the last remaining references to the old name 'vcam-bg'.

## Changes
- Updated config file path in src/config.py to use ~/.config/vidmask/config.json
- Updated .gitignore to use 'vidmask' instead of 'vcam-bg'

## Note
The reference in src/gui/main_window.py is intentionally kept as ~/.config/vcam-bg since it's used for migrating old config files.

## Verification
- [x] Config path updated to new location
- [x] .gitignore updated
- [x] Migration path preserved for backward compatibility